### PR TITLE
Use slf4j-api instead of slf4j-simple

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    slf4jVersion = '1.7.30'
+}
+
 dependencies {
     compile group: 'com.typesafe', name: 'config', version: '1.3.4'
     compile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59'
@@ -26,7 +30,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.12'
-    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.19.v20190610'
     compile group: 'org.jetbrains', name: 'annotations', version: '18.0.0'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
@@ -34,6 +38,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '2.1'
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion
     testCompile group: 'com.codeborne', name: 'selenide', version: '5.5.1'
     testCompile group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.10'


### PR DESCRIPTION
`slf4-simple` is a binding for Slf4j Simple logger (which outputs to standard streams), only `slf4j-api` is needed to enable logging. (Bindings and bridges should be declared by clients consuming the library)