### PR TITLE
Remove 0 content-length header to avoid error

### DIFF
--- a/src/main/java/com/epam/healenium/client/RestClient.java
+++ b/src/main/java/com/epam/healenium/client/RestClient.java
@@ -250,9 +250,7 @@ public class RestClient {
     public void initReport(String sessionId) {
         try {
             HttpRequest request = new HttpRequest(HttpMethod.POST, "/report/init/" + sessionId);
-            request.setHeader("Content-Length", String.valueOf(0));
             request.setHeader("Content-Type", JSON_UTF_8);
-            request.setContent(Contents.bytes(new byte[0]));
             log.debug("[Init Report] Request: {}", request);
             serverHttpClient.execute(request);
         } catch (Exception e) {


### PR DESCRIPTION
Version 3.4.6 of Healenium-Web breaks the initialization of reports (see error below). Removing the content-length header fixes this issue.

```
[http-nio-8080-exec-2] WARN healenium - [Init Report] Error during call. Message: non-positive contentLength: 0, Exception: {}
java.lang.IllegalArgumentException: non-positive contentLength: 0
	at java.net.http/java.net.http.HttpRequest$BodyPublishers.fromPublisher(HttpRequest.java:539)
	at org.openqa.selenium.remote.http.jdk.JdkHttpMessages.notChunkingBodyPublisher(JdkHttpMessages.java:137)
	at org.openqa.selenium.remote.http.jdk.JdkHttpMessages.createRequest(JdkHttpMessages.java:83)
	at org.openqa.selenium.remote.http.jdk.JdkHttpClient.execute(JdkHttpClient.java:369)
	at com.epam.healenium.client.RestClient.initReport(RestClient.java:257)
	at com.epam.healenium.SelfHealingEngine.initReport(SelfHealingEngine.java:189)
	at com.epam.healenium.SelfHealingDriver.callInitActions(SelfHealingDriver.java:66)
	at com.epam.healenium.SelfHealingDriver.create(SelfHealingDriver.java:49)
```