### PR TITLE
Enhanced to generate and support text based Xpaths

### DIFF
--- a/src/main/java/com/epam/healenium/SelectorComponent.java
+++ b/src/main/java/com/epam/healenium/SelectorComponent.java
@@ -12,14 +12,7 @@
  */
 package com.epam.healenium;
 
-import com.epam.healenium.elementcreators.ClassElementCreator;
-import com.epam.healenium.elementcreators.PathElementCreator;
-import com.epam.healenium.elementcreators.PositionElementCreator;
-import com.epam.healenium.elementcreators.AttributesElementCreator;
-import com.epam.healenium.elementcreators.ElementCreator;
-import com.epam.healenium.elementcreators.IdElementCreator;
-import com.epam.healenium.elementcreators.ParentElementCreator;
-import com.epam.healenium.elementcreators.TagElementCreator;
+import com.epam.healenium.elementcreators.*;
 import com.epam.healenium.treecomparing.Node;
 import lombok.AllArgsConstructor;
 
@@ -31,7 +24,8 @@ public enum SelectorComponent {
     ID(new IdElementCreator()),
     CLASS(new ClassElementCreator()),
     POSITION(new PositionElementCreator()),
-    ATTRIBUTES(new AttributesElementCreator());
+    ATTRIBUTES(new AttributesElementCreator()),
+    INNERTEXT(new InnerTextElementCreator());
 
     private final ElementCreator elementCreator;
 

--- a/src/main/java/com/epam/healenium/elementcreators/InnerTextElementCreator.java
+++ b/src/main/java/com/epam/healenium/elementcreators/InnerTextElementCreator.java
@@ -1,0 +1,10 @@
+package com.epam.healenium.elementcreators;
+
+import com.epam.healenium.treecomparing.Node;
+
+public class InnerTextElementCreator implements ElementCreator{
+    @Override
+    public String create(Node node) {
+        return node.getInnerText();
+    }
+}

--- a/src/main/java/com/epam/healenium/service/HealingService.java
+++ b/src/main/java/com/epam/healenium/service/HealingService.java
@@ -44,6 +44,7 @@ public class HealingService {
         add(EnumSet.of(SelectorComponent.PARENT, SelectorComponent.TAG, SelectorComponent.CLASS, SelectorComponent.POSITION));
         add(EnumSet.of(SelectorComponent.PARENT, SelectorComponent.TAG, SelectorComponent.ID, SelectorComponent.CLASS, SelectorComponent.ATTRIBUTES));
         add(EnumSet.of(SelectorComponent.PATH));
+        add(EnumSet.of(SelectorComponent.INNERTEXT));
     }};
 
     public HealingService(Config finalizedConfig, WebDriver driver) {
@@ -93,6 +94,15 @@ public class HealingService {
                 HealedElement healedElement = new HealedElement();
                 healedElement.setElement(elements.get(0)).setScored(byScored);
                 return healedElement;
+            }else
+                locator=constructXPath(node.getValue(), selectorDetailLevels.get(6),"text");
+            elements = driver.findElements(locator);
+            if (elements.size() == 1 && !context.getElementIds().contains(((RemoteWebElement) elements.get(0)).getId())) {
+                Scored<By> byScored = new Scored<>(node.getScore(), locator);
+                context.getElementIds().add(((RemoteWebElement) elements.get(0)).getId());
+                HealedElement healedElement = new HealedElement();
+                healedElement.setElement(elements.get(0)).setScored(byScored);
+                return healedElement;
             }
         }
         return null;
@@ -126,4 +136,18 @@ public class HealingService {
                 .map(component -> component.createComponent(node))
                 .collect(Collectors.joining()));
     }
+
+    /**
+     * Construct xPath by Node
+     * @param node
+     * @param detailLevel
+     * @param attribute
+     * @return
+     */
+    protected By constructXPath(Node node, Set<SelectorComponent> detailLevel,String attribute) {
+        return By.xpath("//"+node.getTag()+"["+attribute+"()='"+detailLevel.stream()
+                .map(component -> component.createComponent(node))
+                .collect(Collectors.joining())+"']");
+    }
 }
+


### PR DESCRIPTION
This PR Contains changes to generate text based xpaths and resolves below bug reported.

### Changes done

1. Created a new elementcreator class to extract the innerText
2. Created a corresponding method to refer to the above elementCreator
3. Created a new method as `constructXPath` to generate a xpath
4. Introduced a new logic to resolve the locator in `toLocator` method by using `constructXPath` if `elements.size() == 1` returns false


Eg: 
`By.xpath("//div[text()='Environment Configuration']")`

Bug - https://github.com/healenium/healenium-web/issues/253  


### Note 
This fix was **tested for Kubernetes** as well by simply overriding the hlm-web dependency found as a transitive dependency within healenium-appium for hlm-proxy